### PR TITLE
#18 fix: Address issue with decorator

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,10 +33,10 @@ jobs:
         poetry install
     - name: Check formatting with black
       run: |
-        black --check .
+        poetry run black --check .
     - name: Check typing annotations with mypy
       run: |
-        mypy .
+        poetry run mypy .
     - name: Test with pytest
       run: |
-        pytest
+        poetry run pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.3
+      uses: snok/install-poetry@v1.1.1
       with:
         # Version of Poetry to use
-        version: 1.0.10
+        version: 1.1.4
     - name: Install dependencies
       run: |
         poetry install

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,11 @@ The above app will have a route `t1` that will accept up to 5 requests per minut
     @limiter.limit("5/minute")
     async def homepage(request: Request):
         return PlainTextResponse("test")
+
+    @app.get("/mars")
+    @limiter.limit("5/minute")
+    async def homepage(request: Request, response: Response):
+        return {"key": "value"}
 ```
 
 This will provide the same result, but with a FastAPI app.
@@ -84,6 +89,17 @@ and not:
     async def myendpoint()
         pass
 ```
+
+  * Similarly, if the returned response is not an instance of `Response` and
+will be built at an upper level in the middleware stack, you'll need to provide
+the response object explicitly if you want the `Limiter` to modify the headers
+(`headers_enabled=True`):
+
+    ```python
+    @limiter.limit("5/minute")
+    async def myendpoint(request: Request, response: Response)
+        return {"key": "value"}
+    ```
 
   * `websocket` endpoints are not supported yet.
 

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -629,7 +629,9 @@ class Limiter:
                     response = await func(*args, **kwargs)  # type: ignore
                     if not isinstance(response, Response):
                         # get the response object from the decorated endpoint function
-                        self._inject_headers(kwargs.get("response"), request.state.view_rate_limit)
+                        self._inject_headers(
+                            kwargs.get("response"), request.state.view_rate_limit
+                        )
                     else:
                         self._inject_headers(response, request.state.view_rate_limit)
                     return response
@@ -655,7 +657,9 @@ class Limiter:
                     response = func(*args, **kwargs)
                     if not isinstance(response, Response):
                         # get the response object from the decorated endpoint function
-                        self._inject_headers(kwargs.get("response"), request.state.view_rate_limit)
+                        self._inject_headers(
+                            kwargs.get("response"), request.state.view_rate_limit
+                        )
                     else:
                         self._inject_headers(response, request.state.view_rate_limit)
                     return response

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -374,7 +374,6 @@ class Limiter:
                 )
 
                 # response may have an existing retry after
-                print(response.headers)
                 existing_retry_after_header = response.headers.get("Retry-After")
 
                 if existing_retry_after_header is not None:

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -627,7 +627,7 @@ class Limiter:
                         self._check_request_limit(request, func, False)
                         request.state._rate_limiting_complete = True
                     response = await func(*args, **kwargs)  # type: ignore
-                    if self._headers_enabled and not isinstance(response, Response):
+                    if not isinstance(response, Response):
                         # get the response object from the decorated endpoint function
                         self._inject_headers(kwargs.get("response"), request.state.view_rate_limit)
                     else:

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -630,7 +630,7 @@ class Limiter:
                     if not isinstance(response, Response):
                         # get the response object from the decorated endpoint function
                         self._inject_headers(
-                            kwargs.get("response"), request.state.view_rate_limit
+                            kwargs.get("response"), request.state.view_rate_limit  # type: ignore
                         )
                     else:
                         self._inject_headers(response, request.state.view_rate_limit)
@@ -658,7 +658,7 @@ class Limiter:
                     if not isinstance(response, Response):
                         # get the response object from the decorated endpoint function
                         self._inject_headers(
-                            kwargs.get("response"), request.state.view_rate_limit
+                            kwargs.get("response"), request.state.view_rate_limit  # type: ignore
                         )
                     else:
                         self._inject_headers(response, request.state.view_rate_limit)

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -1,7 +1,7 @@
 import hiro  # type: ignore
 import pytest  # type: ignore
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse
+from starlette.responses import PlainTextResponse, Response
 from starlette.testclient import TestClient
 
 from slowapi.util import get_ipaddr
@@ -22,6 +22,50 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
 
+
+    def test_single_decorator_with_headers(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+
+        @app.get("/t1")
+        @limiter.limit("5/minute")
+        async def t1(request: Request):
+            return PlainTextResponse("test")
+
+        client = TestClient(app)
+        for i in range(0, 10):
+            response = client.get("/t1")
+            assert response.status_code == 200 if i < 5 else 429
+            assert response.headers.get('X-RateLimit-Limit') is not None if i < 5 else True
+            assert response.headers.get('Retry-After') is not None if i < 5 else True
+
+    def test_single_decorator_not_response(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+
+        @app.get("/t1")
+        @limiter.limit("5/minute")
+        async def t1(request: Request, response: Response):
+            return {"key": "value"}
+
+        client = TestClient(app)
+        for i in range(0, 10):
+            response = client.get("/t1")
+            assert response.status_code == 200 if i < 5 else 429
+
+    def test_single_decorator_not_response_with_headers(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+
+        @app.get("/t1")
+        @limiter.limit("5/minute")
+        async def t1(request: Request):
+            return PlainTextResponse("test")
+
+        client = TestClient(app)
+        for i in range(0, 10):
+            response = client.get("/t1")
+            assert response.status_code == 200 if i < 5 else 429
+            assert response.headers.get('X-RateLimit-Limit') is not None if i < 5 else True
+            assert response.headers.get('Retry-After') is not None if i < 5 else True
+
     def test_multiple_decorators(self):
         app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
 
@@ -32,6 +76,31 @@ class TestDecorators(TestSlowapi):
         @limiter.limit("50/minute")  # per ip as per default key_func
         async def t1(request: Request):
             return PlainTextResponse("test")
+
+        with hiro.Timeline().freeze() as timeline:
+            cli = TestClient(app)
+            for i in range(0, 100):
+                response = cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.2"})
+                assert response.status_code == 200 if i < 50 else 429
+            for i in range(50):
+                assert cli.get("/t1").status_code == 200
+
+            assert cli.get("/t1").status_code == 429
+            assert (
+                cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.3"}).status_code
+                == 429
+            )
+
+    def test_multiple_decorators_not_response(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+
+        @app.get("/t1")
+        @limiter.limit(
+            "100 per minute", lambda: "test"
+        )  # effectively becomes a limit for all users
+        @limiter.limit("50/minute")  # per ip as per default key_func
+        async def t1(request: Request, response: Response):
+            return {"key":"value"}
 
         with hiro.Timeline().freeze() as timeline:
             cli = TestClient(app)
@@ -90,6 +159,21 @@ class TestDecorators(TestSlowapi):
             r"""parameter `request` must be an instance of starlette.requests.Request"""
         )
 
+    def test_endpoint_response_param_invalid(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+
+        @app.get("/t4")
+        @limiter.limit("5/minute")
+        async def t4(request: Request, response: str = None):
+            return {"key": "value"}
+
+        with pytest.raises(Exception) as exc_info:
+            client = TestClient(app)
+            client.get("/t4")
+        assert exc_info.match(
+            r"""parameter `response` must be an instance of starlette.responses.Response"""
+        )
+
     def test_endpoint_request_param_invalid_sync(self):
         app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
 
@@ -103,4 +187,19 @@ class TestDecorators(TestSlowapi):
             client.get("/t5")
         assert exc_info.match(
             r"""parameter `request` must be an instance of starlette.requests.Request"""
+        )
+
+    def test_endpoint_response_param_invalid_sync(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+
+        @app.get("/t5")
+        @limiter.limit("5/minute")
+        def t5(request: Request, response: str = None):
+            return {"key": "value"}
+
+        with pytest.raises(Exception) as exc_info:
+            client = TestClient(app)
+            client.get("/t5")
+        assert exc_info.match(
+            r"""parameter `response` must be an instance of starlette.responses.Response"""
         )

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -56,8 +56,8 @@ class TestDecorators(TestSlowapi):
 
         @app.get("/t1")
         @limiter.limit("5/minute")
-        async def t1(request: Request):
-            return PlainTextResponse("test")
+        async def t1(request: Request, response: Response):
+            return {"key": "value"}
 
         client = TestClient(app)
         for i in range(0, 10):

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -22,7 +22,6 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
 
-
     def test_single_decorator_with_headers(self):
         app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
@@ -35,8 +34,10 @@ class TestDecorators(TestSlowapi):
         for i in range(0, 10):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
-            assert response.headers.get('X-RateLimit-Limit') is not None if i < 5 else True
-            assert response.headers.get('Retry-After') is not None if i < 5 else True
+            assert (
+                response.headers.get("X-RateLimit-Limit") is not None if i < 5 else True
+            )
+            assert response.headers.get("Retry-After") is not None if i < 5 else True
 
     def test_single_decorator_not_response(self):
         app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
@@ -63,8 +64,10 @@ class TestDecorators(TestSlowapi):
         for i in range(0, 10):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
-            assert response.headers.get('X-RateLimit-Limit') is not None if i < 5 else True
-            assert response.headers.get('Retry-After') is not None if i < 5 else True
+            assert (
+                response.headers.get("X-RateLimit-Limit") is not None if i < 5 else True
+            )
+            assert response.headers.get("Retry-After") is not None if i < 5 else True
 
     def test_multiple_decorators(self):
         app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
@@ -100,7 +103,7 @@ class TestDecorators(TestSlowapi):
         )  # effectively becomes a limit for all users
         @limiter.limit("50/minute")  # per ip as per default key_func
         async def t1(request: Request, response: Response):
-            return {"key":"value"}
+            return {"key": "value"}
 
         with hiro.Timeline().freeze() as timeline:
             cli = TestClient(app)


### PR DESCRIPTION
The value returned by an endpoint may not be an instance or subclass
of `Response`, in this case FastAPI builds the actual Response
at an upper level in the middleware stack.
This patch allows the decorator to inspect the endpoint to retrieve the
associated `Response` to allow headers to be injected.

This should resolve #18 
