### PR TITLE
Fix issues with CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,10 +33,10 @@ jobs:
         poetry install
     - name: Check formatting with black
       run: |
-        black --check .
+        poetry run black --check .
     - name: Check typing annotations with mypy
       run: |
-        mypy .
+        poetry run mypy .
     - name: Test with pytest
       run: |
-        pytest
+        poetry run pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.3
+      uses: snok/install-poetry@v1.1.1
       with:
         # Version of Poetry to use
-        version: 1.0.10
+        version: 1.1.4
     - name: Install dependencies
       run: |
         poetry install


### PR DESCRIPTION
This PR fixes the CI run which broke following https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/. Specifically, the poetry action we were using had to be replaced by a new, maintained one.

I tried to add support for python 3.9 in the same PR, but found errors, so moved this to #21 instead.