### PR TITLE
fix: Address a problem with multiple decorator and headers

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -378,16 +378,18 @@ class Limiter:
 
                 if existing_retry_after_header is not None:
                     # might be in http-date format
-                    retry_after = parsedate_to_datetime(existing_retry_after_header)
+                    try:
+                        retry_after = parsedate_to_datetime(existing_retry_after_header)
+                    except TypeError:
+                        retry_after = None
 
-                    # parse_date failure returns None
                     if retry_after is None:
                         retry_after = time.time() + int(existing_retry_after_header)
 
                     if isinstance(retry_after, datetime.datetime):
-                        retry_after_int: int = int(time.mktime(retry_after.timetuple()))
+                        retry_after = time.mktime(retry_after.timetuple())
 
-                    reset_in = max(retry_after_int, reset_in)
+                    reset_in = max(int(retry_after), reset_in)
 
                 response.headers[self._header_mapping[HEADERS.RETRY_AFTER]] = (
                     formatdate(reset_in)

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -381,15 +381,15 @@ class Limiter:
                     try:
                         retry_after = parsedate_to_datetime(existing_retry_after_header)
                     except TypeError:
-                        retry_after = None
+                        retry_after = None  # type: ignore
 
                     if retry_after is None:
-                        retry_after = time.time() + int(existing_retry_after_header)
+                        retry_after = time.time() + int(existing_retry_after_header)  # type: ignore
 
                     if isinstance(retry_after, datetime.datetime):
-                        retry_after = time.mktime(retry_after.timetuple())
+                        retry_after = time.mktime(retry_after.timetuple())  # type: ignore
 
-                    reset_in = max(int(retry_after), reset_in)
+                    reset_in = max(int(retry_after), reset_in)  # type: ignore
 
                 response.headers[self._header_mapping[HEADERS.RETRY_AFTER]] = (
                     formatdate(reset_in)

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -119,6 +119,31 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
+    def test_multiple_decorators_not_response_with_headers(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+
+        @app.get("/t1")
+        @limiter.limit(
+            "100 per minute", lambda: "test"
+        )  # effectively becomes a limit for all users
+        @limiter.limit("50/minute")  # per ip as per default key_func
+        async def t1(request: Request, response: Response):
+            return {"key": "value"}
+
+        with hiro.Timeline().freeze() as timeline:
+            cli = TestClient(app)
+            for i in range(0, 100):
+                response = cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.2"})
+                assert response.status_code == 200 if i < 50 else 429
+            for i in range(50):
+                assert cli.get("/t1").status_code == 200
+
+            assert cli.get("/t1").status_code == 429
+            assert (
+                cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.3"}).status_code
+                == 429
+            )
+
     def test_endpoint_missing_request_param(self):
         app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
 

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -91,6 +91,33 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
+    def test_multiple_decorators_with_headers(self):
+        app, limiter = self.build_starlette_app(
+            key_func=get_ipaddr, headers_enabled=True
+        )
+
+        @limiter.limit("10 per minute", lambda: "test")
+        @limiter.limit("5/minute")  # per ip as per default key_func
+        async def t1(request: Request):
+            return PlainTextResponse("test")
+
+        app.add_route("/t1", t1)
+
+        with hiro.Timeline().freeze() as timeline:
+            cli = TestClient(app)
+            for i in range(0, 10):
+                response = cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.2"})
+                assert response.status_code == 200 if i < 5 else 429
+                assert response.headers.get('Retry-After') if i < 5 else True
+            for i in range(5):
+                assert cli.get("/t1").status_code == 200
+
+            assert cli.get("/t1").status_code == 429
+            assert (
+                cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.3"}).status_code
+                == 429
+            )
+
     def test_headers_no_breach(self):
         app, limiter = self.build_starlette_app(
             headers_enabled=True, key_func=get_remote_address
@@ -140,7 +167,6 @@ class TestDecorators(TestSlowapi):
                     resp = cli.get("/t1")
                     timeline.forward(1)
 
-                print(resp.headers)
                 assert resp.headers.get("X-RateLimit-Limit") == "10"
                 assert resp.headers.get("X-RateLimit-Remaining") == "0"
                 assert resp.headers.get("X-RateLimit-Reset") == str(

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -108,7 +108,7 @@ class TestDecorators(TestSlowapi):
             for i in range(0, 10):
                 response = cli.get("/t1", headers={"X_FORWARDED_FOR": "127.0.0.2"})
                 assert response.status_code == 200 if i < 5 else 429
-                assert response.headers.get('Retry-After') if i < 5 else True
+                assert response.headers.get("Retry-After") if i < 5 else True
             for i in range(5):
                 assert cli.get("/t1").status_code == 200
 


### PR DESCRIPTION
If `headers_enabled` and multiple decorators are used, current code is
failing on correctly parsing the `Retry-After` header.
Added try/except to `parsedate_to_datetime` as it may raise errors
(contrary to documentation) and adapt code accordingly.