### PR TITLE
Resolving bug of unregistered endpoints in the disabled state.

### DIFF
--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -54,8 +54,6 @@ class SlowAPIMiddleware(BaseHTTPMiddleware):
                 return exception_handler(request, e)
             # request.state._rate_limiting_complete = True
             response = await call_next(request)
-            response = limiter._inject_headers(
-                response, request.state.view_rate_limit
-            )
+            response = limiter._inject_headers(response, request.state.view_rate_limit)
             return response
         return await call_next(request)

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -51,6 +51,7 @@ class SlowAPIMiddleware(BaseHTTPMiddleware):
                 return exception_handler(request, e)
             # request.state._rate_limiting_complete = True
             response = await call_next(request)
-            response = limiter._inject_headers(response, request.state.view_rate_limit)
+            if limiter.enabled:
+                response = limiter._inject_headers(response, request.state.view_rate_limit)
             return response
         return await call_next(request)

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -52,6 +52,8 @@ class SlowAPIMiddleware(BaseHTTPMiddleware):
             # request.state._rate_limiting_complete = True
             response = await call_next(request)
             if limiter.enabled:
-                response = limiter._inject_headers(response, request.state.view_rate_limit)
+                response = limiter._inject_headers(
+                    response, request.state.view_rate_limit
+                )
             return response
         return await call_next(request)

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -223,6 +223,10 @@ class TestDecorators(TestSlowapi):
         def t2(request: Request):
             return PlainTextResponse("test")
 
+        @app.get("/t3")
+        def t3(request: Request):
+            return PlainTextResponse("also a test")
+
         client = TestClient(app)
         for i in range(0, 10):
             response = client.get("/t1")
@@ -230,4 +234,8 @@ class TestDecorators(TestSlowapi):
 
         for i in range(0, 10):
             response = client.get("/t2")
+            assert response.status_code == 200
+
+        for i in range(0, 10):
+            response = client.get("/t3")
             assert response.status_code == 200


### PR DESCRIPTION
When an endpoint is not decorated but the middleware is disabled, any request to the undecorated endpoint fails.  This particularly impacts endpoints automatically generated by the FastAPI framework (`/docs`, eg.) 