### PR TITLE
Re-add python 3.9 support in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
@twcurrie I think I messed up on the previous PR, because I first mistakenly committed straight to `master` to add 3.9, then branched off for the PR, and later reverted my commit on `master`. So the merge ended up without 3.9 :(

Anyway, this one should do it. Feel free to approve/merge :)