### PR TITLE
Add Request module

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ The above app will have a route `t1` that will accept up to 5 requests per minut
 ## FastAPI
 
 ```python
-    from fastapi import FastAPI
+    from fastapi import FastAPI, Request
     from slowapi import Limiter, _rate_limit_exceeded_handler
     from slowapi.util import get_remote_address
     from slowapi.errors import RateLimitExceeded


### PR DESCRIPTION
Added `Request` module for fastAPI example code. If the `Request` module is not added, an error is received when the code is executed.