### PR TITLE
Fix import issues in examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,12 +54,12 @@ The above app will have a route `t1` that will accept up to 5 requests per minut
     # Note: the route decorator must be above the limit decorator, not below it
     @app.get("/home")
     @limiter.limit("5/minute")
-    async def homepage(request: Request):
+    async def home(request: Request):
         return Response("test")
 
     @app.get("/mars")
     @limiter.limit("5/minute")
-    async def homepage(request: Request, response: Response):
+    async def mars(request: Request, response: Response):
         return {"key": "value"}
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ $ pip install slowapi
 
 ```python
     from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.requests import Request
     from slowapi import Limiter, _rate_limit_exceeded_handler
     from slowapi.util import get_remote_address
     from slowapi.errors import RateLimitExceeded
@@ -39,7 +41,7 @@ The above app will have a route `t1` that will accept up to 5 requests per minut
 ## FastAPI
 
 ```python
-    from fastapi import FastAPI, Request
+    from fastapi import FastAPI, Request, Response
     from slowapi import Limiter, _rate_limit_exceeded_handler
     from slowapi.util import get_remote_address
     from slowapi.errors import RateLimitExceeded
@@ -53,7 +55,7 @@ The above app will have a route `t1` that will accept up to 5 requests per minut
     @app.get("/home")
     @limiter.limit("5/minute")
     async def homepage(request: Request):
-        return PlainTextResponse("test")
+        return Response("test")
 
     @app.get("/mars")
     @limiter.limit("5/minute")


### PR DESCRIPTION
This PR fixes a couple of missing imports in the FastAPI and Starlette examples in the docs.

Also, it fixes issue #75 where the limit counter of both routes in the FlaskAPI example were incorrectly shared due to a duplicate method name.