### PR TITLE
Do not allow duplicate view method names

### DIFF
--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -264,3 +264,18 @@ class TestDecorators(TestSlowapi):
         for i in range(0, 10):
             response = client.get("/t3")
             assert response.status_code == 200
+
+    def test_duplicate_method_names(self):
+        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+
+        @limiter.limit("5 per minute")
+        async def t1(request: Request):
+            return PlainTextResponse("test")
+
+        with pytest.raises(ValueError) as exc_info:
+
+            @limiter.limit("5 per minute")
+            async def t1(request: Request):
+                return PlainTextResponse("test")
+
+        assert exc_info.match(r"""^Duplicate method name marked for limiting: .*$""")


### PR DESCRIPTION
Using duplicated method names for different views causes slowapi to count one request to one of the routes multiple times, causing the limit treshold to be hit too early.

This commit makes sure a ValueError is raised whenever duplicate view methods are marked for limiting.

An alternative would be to fix the underlying counting issue and allow users to name view methods the same, but unfortunately I can't find a way to implement this without it being way too complicated for how small the use case is.

Related issues: #75, #76