### PR TITLE
Publish release to testpypi from github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-and-publish:
 
     runs-on: ubuntu-latest
     strategy:
@@ -18,9 +18,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install build dependencies for requests in python 3.9
@@ -30,7 +30,7 @@ jobs:
       uses: snok/install-poetry@v1
       with:
         # Version of Poetry to use
-        version: 1.1.11
+        version: 1.1.15
     - name: Install dependencies
       run: |
         poetry install
@@ -50,3 +50,15 @@ jobs:
     - name: Generate coverage report
       run: |
         poetry run coverage report
+
+    - name: Build distribution tarball and wheel
+      # TODO: restrict this to master branch only
+      if: startsWith(github.ref, 'refs/tags')
+      run: |
+        poetry build
+
+    - name: Publish release to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      # uses POETRY_REPOSITORIES_TESTPYPI, POETRY_PYPI_TOKEN_TESTPYPI env vars
+      run: |
+        poetry publish --repository testpypi

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,12 +163,12 @@ $ pytest
 
 `slowapi` tries to follow [semantic versioning](https://semver.org/).
 
-To release a new version:
-
-- Update CHANGELOG.md
-- Bump the version number is `pyproject.toml`
-- `poetry build`
-- `poetry publish`
+Releases are published directly from CI (github actions). To create a new release:
+- Update `CHANGELOG.md` and the version in `pyproject.toml`,
+- Commit those changes to a new PR,
+- Get the PR reviewed and merged,
+- Tag the merge commit with the same version number prefixed with `v`, eg. `v0.1.6`,
+- Push the tag to trigger the release.
 
 # Credits
 


### PR DESCRIPTION
This is a draft of what an automatic package publishing workflow could look like.

TODO:
- [ ] Add automatic changelogs
- [ ] Allow publishing only from `master` branch
- [ ] Restrict publishing to allowed contributors
- [ ] switch from testpypi to production pypi once everything else is done