### PR TITLE
new: :sparkles: add ASGI middleware alternative

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -81,3 +81,24 @@ Define a function which takes a request as parameter and returns a cost and pass
     def t(request: Request):
         return PlainTextResponse("I'm limited by the request size")
 ```
+
+## WSGI vs ASGI Middleware
+
+`SlowAPIMiddleware` inheriting from Starlette's BaseHTTPMiddleware, you can find an alternative ASGI Middleware `SlowAPIASGIMiddleware`.  
+A few reasons to choose the ASGI middleware over the HTTP one are:
+- Starlette [is probably going to deprecate BaseHTTPMiddleware](https://github.com/encode/starlette/issues/1678)
+- ASGI middlewares [are more performant than WSGI ones](https://github.com/tiangolo/fastapi/issues/2241)
+- built-in support for asynchronous exception handlers
+- ...
+
+
+Both middlewares are added to your application the same way:
+```python
+app = Starlette() # or FastAPI()
+app.add_middleware(SlowAPIMiddleware)
+```
+or
+```python
+app = Starlette() # or FastAPI()
+app.add_middleware(SlowAPIASGIMiddleware)
+```

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -420,6 +420,13 @@ class Limiter:
     def _inject_asgi_headers(
         self, headers: MutableHeaders, current_limit: Tuple[RateLimitItem, List[str]]
     ) -> MutableHeaders:
+        """
+        Injects 'X-RateLimit-Reset', 'X-RateLimit-Remaining', 'X-RateLimit-Limit'
+        and 'Retry-After' headers into :headers parameter if needed.
+
+        Basically the same as _inject_headers, but without access to the Response object.
+        -> supports ASGI Middlewares.
+        """
         if self.enabled and self._headers_enabled and current_limit is not None:
             try:
                 window_stats: Tuple[int, int] = self.limiter.get_window_stats(

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -540,7 +540,7 @@ class Limiter:
     def _check_request_limit(
         self,
         request: Request,
-        endpoint_func: Callable[..., Any],
+        endpoint_func: Optional[Callable[..., Any]],
         in_middleware: bool = True,
     ) -> None:
         """

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -27,7 +27,7 @@ def _find_route_handler(
 
 
 def _get_route_name(handler: Callable):
-    return "%s.%s" % (handler.__module__, handler.__name__)
+    return f"{handler.__module__}.{handler.__name__}"
 
 
 def _check_limits(

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from starlette.applications import Starlette
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import (
     BaseHTTPMiddleware,
     RequestResponseEndpoint,
@@ -6,6 +9,7 @@ from starlette.middleware.base import (
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Match
+from starlette.types import ASGIApp, Message, Scope, Receive, Send
 
 from slowapi import Limiter, _rate_limit_exceeded_handler
 
@@ -54,3 +58,89 @@ class SlowAPIMiddleware(BaseHTTPMiddleware):
             response = limiter._inject_headers(response, request.state.view_rate_limit)
             return response
         return await call_next(request)
+
+
+class SlowAPIASGIMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self.error_response: Optional[Response] = None
+        self.initial_message: Message = {}
+        self.inject_headers = False
+
+    async def send_wrapper(self, message: Message):
+        if message["type"] == "http.response.start":
+            # do not send the http.response.start message now, so that we can edit the headers
+            # before sending it, based on what happens in the http.response.body message.
+            self.initial_message = message
+
+        elif message["type"] == "http.response.body":
+            if self.error_response:
+                self.initial_message["status"] = self.error_response.status_code
+
+            if self.inject_headers:
+                headers = MutableHeaders(raw=self.initial_message["headers"])
+                headers = self.limiter._inject_asgi_headers(
+                    headers, self.request.state.view_rate_limit
+                )
+
+            # send the http.response.start message just before the http.response.body one,
+            # now that the headers are updated
+            await self.send(self.initial_message)
+            await self.send(message)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        self.send = send
+
+        _app: Starlette = scope["app"]
+        limiter: Limiter = _app.state.limiter
+        handler = None
+
+        if not limiter.enabled:
+            return await self.app(scope, receive, self.send)
+
+        for route in _app.routes:
+            match, _ = route.matches(scope)
+            if match == Match.FULL and hasattr(route, "endpoint"):
+                handler = route.endpoint  # type: ignore
+
+        # if we can't find the route handler
+        if handler is None:
+            return await self.app(scope, receive, self.send)
+
+        name = "%s.%s" % (handler.__module__, handler.__name__)
+
+        # if exempt no need to check
+        if name in limiter._exempt_routes:
+            return await self.app(scope, receive, self.send)
+
+        # there is a decorator for this route we let the decorator handle it
+        if name in limiter._route_limits:
+            return await self.app(scope, receive, self.send)
+
+        # Limit
+        request = Request(scope, receive=receive, send=self.send)
+
+        # let the decorator handle if already in
+        if limiter._auto_check and not getattr(
+            request.state, "_rate_limiting_complete", False
+        ):
+            try:
+                limiter._check_request_limit(request, handler, True)
+            except Exception as e:
+                # handle the exception since the global exception handler won't pick exceptions
+                # raised from an ASGI Middleware
+                exception_handler = _app.exception_handlers.get(
+                    type(e), _rate_limit_exceeded_handler
+                )
+                response = exception_handler(request, e)
+                self.error_response = response
+                return await response(scope, receive, self.send_wrapper)
+
+            self.inject_headers = True
+            self.limiter = limiter
+            self.request = request
+        return await self.app(scope, receive, self.send_wrapper)

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Iterable, Tuple
 
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
@@ -8,10 +8,61 @@ from starlette.middleware.base import (
 )
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import Match
+from starlette.routing import BaseRoute, Match
 from starlette.types import ASGIApp, Message, Scope, Receive, Send
 
 from slowapi import Limiter, _rate_limit_exceeded_handler
+
+
+def _find_route_handler(routes: Iterable[BaseRoute], scope: Scope):
+    handler = None
+    for route in routes:
+        match, _ = route.matches(scope)
+        if match == Match.FULL and hasattr(route, "endpoint"):
+            handler = route.endpoint  # type: ignore
+    return handler
+
+
+def _get_route_name(handler):
+    return "%s.%s" % (handler.__module__, handler.__name__)
+
+
+def _check_limits(
+    limiter: Limiter, request: Request, handler, app: Starlette
+) -> Tuple[Optional[Response], bool]:
+    if limiter._auto_check and not getattr(
+        request.state, "_rate_limiting_complete", False
+    ):
+        try:
+            limiter._check_request_limit(request, handler, True)
+        except Exception as e:
+            # handle the exception since the global exception handler won't pick it up if we call_next
+            exception_handler = app.exception_handlers.get(
+                type(e), _rate_limit_exceeded_handler
+            )
+            return exception_handler(request, e), False
+        # request.state._rate_limiting_complete = True
+
+        return None, True
+    return None, False
+
+
+def _should_exempt(limiter: Limiter, handler) -> bool:
+    # if we can't find the route handler
+    if handler is None:
+        return True
+
+    name = _get_route_name(handler)
+
+    # if exempt no need to check
+    if name in limiter._exempt_routes:
+        return True
+
+    # there is a decorator for this route we let the decorator handle it
+    if name in limiter._route_limits:
+        return True
+
+    return False
 
 
 class SlowAPIMiddleware(BaseHTTPMiddleware):
@@ -20,44 +71,24 @@ class SlowAPIMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         app: Starlette = request.app
         limiter: Limiter = app.state.limiter
-        handler = None
+
         if not limiter.enabled:
             return await call_next(request)
 
-        for route in app.routes:
-            match, _ = route.matches(request.scope)
-            if match == Match.FULL and hasattr(route, "endpoint"):
-                handler = route.endpoint  # type: ignore
-        # if we can't find the route handler
-        if handler is None:
+        handler = _find_route_handler(app.routes, request.scope)
+        if _should_exempt(limiter, handler):
             return await call_next(request)
 
-        name = "%s.%s" % (handler.__module__, handler.__name__)
-        # if exempt no need to check
-        if name in limiter._exempt_routes:
-            return await call_next(request)
+        error_response, should_inject_headers = _check_limits(
+            limiter, request, handler, app
+        )
+        if error_response is not None:
+            return error_response
 
-        # there is a decorator for this route we let the decorator handle it
-        if name in limiter._route_limits:
-            return await call_next(request)
-
-        # let the decorator handle if already in
-        if limiter._auto_check and not getattr(
-            request.state, "_rate_limiting_complete", False
-        ):
-            try:
-                limiter._check_request_limit(request, handler, True)
-            except Exception as e:
-                # handle the exception since the global exception handler won't pick it up if we call_next
-                exception_handler = app.exception_handlers.get(
-                    type(e), _rate_limit_exceeded_handler
-                )
-                return exception_handler(request, e)
-            # request.state._rate_limiting_complete = True
-            response = await call_next(request)
+        response = await call_next(request)
+        if should_inject_headers:
             response = limiter._inject_headers(response, request.state.view_rate_limit)
-            return response
-        return await call_next(request)
+        return response
 
 
 class SlowAPIASGIMiddleware:
@@ -97,50 +128,25 @@ class SlowAPIASGIMiddleware:
 
         _app: Starlette = scope["app"]
         limiter: Limiter = _app.state.limiter
-        handler = None
 
         if not limiter.enabled:
             return await self.app(scope, receive, self.send)
 
-        for route in _app.routes:
-            match, _ = route.matches(scope)
-            if match == Match.FULL and hasattr(route, "endpoint"):
-                handler = route.endpoint  # type: ignore
-
-        # if we can't find the route handler
-        if handler is None:
-            return await self.app(scope, receive, self.send)
-
-        name = "%s.%s" % (handler.__module__, handler.__name__)
-
-        # if exempt no need to check
-        if name in limiter._exempt_routes:
-            return await self.app(scope, receive, self.send)
-
-        # there is a decorator for this route we let the decorator handle it
-        if name in limiter._route_limits:
-            return await self.app(scope, receive, self.send)
-
-        # Limit
+        handler = _find_route_handler(_app.routes, scope)
         request = Request(scope, receive=receive, send=self.send)
+        if _should_exempt(limiter, handler):
+            return await self.app(scope, receive, self.send)
 
         # let the decorator handle if already in
-        if limiter._auto_check and not getattr(
-            request.state, "_rate_limiting_complete", False
-        ):
-            try:
-                limiter._check_request_limit(request, handler, True)
-            except Exception as e:
-                # handle the exception since the global exception handler won't pick exceptions
-                # raised from an ASGI Middleware
-                exception_handler = _app.exception_handlers.get(
-                    type(e), _rate_limit_exceeded_handler
-                )
-                response = exception_handler(request, e)
-                self.error_response = response
-                return await response(scope, receive, self.send_wrapper)
+        error_response, should_inject_headers = _check_limits(
+            limiter, request, handler, _app
+        )
+        if error_response is not None:
+            return await error_response(scope, receive, self.send_wrapper)
 
+        if should_inject_headers:
             self.inject_headers = True
             self.limiter = limiter
             self.request = request
+
         return await self.app(scope, receive, self.send_wrapper)

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Callable, Iterable, Optional, Tuple, Type
+from typing import Callable, Iterable, Optional, Tuple
 
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Callable, Coroutine, Iterable, Optional, Tuple, Type, Union
+from typing import Callable, Iterable, Optional, Tuple, Type
 
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
@@ -26,13 +26,13 @@ def _find_route_handler(
     return handler
 
 
-def _get_route_name(handler: Type[Callable]):
+def _get_route_name(handler: Callable):
     return "%s.%s" % (handler.__module__, handler.__name__)
 
 
 def _check_limits(
     limiter: Limiter, request: Request, handler: Optional[Callable], app: Starlette
-) -> Tuple[Optional[Union[Callable, Coroutine]], bool, Optional[Exception]]:
+) -> Tuple[Optional[Callable], bool, Optional[Exception]]:
     """
     Utils to check (if needed) current requests limit.
     It returns a tuple of size 3:
@@ -74,7 +74,7 @@ def sync_check_limits(
     if inspect.iscoroutinefunction(exception_handler):
         exception_handler = _rate_limit_exceeded_handler
 
-    return exception_handler(request, exc), _bool
+    return exception_handler(request, exc), _bool  # type: ignore
 
 
 async def async_check_limits(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,11 @@
+import asyncio
 import logging
 
 import pytest
 from fastapi import FastAPI
 from mock import mock  # type: ignore
 from starlette.applications import Starlette
+from starlette.requests import Request
 
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import Limiter, _rate_limit_exceeded_handler
@@ -11,16 +13,29 @@ from slowapi.middleware import SlowAPIMiddleware, SlowAPIASGIMiddleware
 from slowapi.util import get_remote_address
 
 
+async def _async_rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):
+    await asyncio.sleep(0)
+    return _rate_limit_exceeded_handler(request, exc)
+
+
 class TestSlowapi:
-    @pytest.fixture(params=[SlowAPIMiddleware, SlowAPIASGIMiddleware])
+    @pytest.fixture(
+        params=[
+            (SlowAPIMiddleware, _rate_limit_exceeded_handler),
+            (SlowAPIASGIMiddleware, _rate_limit_exceeded_handler),
+            (SlowAPIASGIMiddleware, _async_rate_limit_exceeded_handler),
+        ]
+    )
     def build_starlette_app(self, request):
         def _factory(config={}, **limiter_args):
+            middleware, exception_handler = request.param
+
             limiter_args.setdefault("key_func", get_remote_address)
             limiter = Limiter(**limiter_args)
             app = Starlette(debug=True)
             app.state.limiter = limiter
-            app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
-            app.add_middleware(request.param)
+            app.add_exception_handler(RateLimitExceeded, exception_handler)
+            app.add_middleware(middleware)
 
             mock_handler = mock.Mock()
             mock_handler.level = logging.INFO
@@ -29,14 +44,22 @@ class TestSlowapi:
 
         return _factory
 
-    @pytest.fixture(params=[SlowAPIMiddleware, SlowAPIASGIMiddleware])
+    @pytest.fixture(
+        params=[
+            (SlowAPIMiddleware, _rate_limit_exceeded_handler),
+            (SlowAPIASGIMiddleware, _rate_limit_exceeded_handler),
+            (SlowAPIASGIMiddleware, _async_rate_limit_exceeded_handler),
+        ]
+    )
     def build_fastapi_app(self, request):
         def _factory(config={}, **limiter_args):
+            middleware, exception_handler = request.param
             limiter_args.setdefault("key_func", get_remote_address)
             limiter = Limiter(**limiter_args)
             app = FastAPI()
             app.state.limiter = limiter
-            app.add_middleware(request.param)
+            app.add_exception_handler(RateLimitExceeded, exception_handler)
+            app.add_middleware(middleware)
 
             mock_handler = mock.Mock()
             mock_handler.level = logging.INFO

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,37 +1,46 @@
 import logging
 
+import pytest
 from fastapi import FastAPI
 from mock import mock  # type: ignore
 from starlette.applications import Starlette
 
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import Limiter, _rate_limit_exceeded_handler
-from slowapi.middleware import SlowAPIMiddleware
+from slowapi.middleware import SlowAPIMiddleware, SlowAPIASGIMiddleware
 from slowapi.util import get_remote_address
 
 
 class TestSlowapi:
-    def build_starlette_app(self, config={}, **limiter_args):
-        limiter_args.setdefault("key_func", get_remote_address)
-        limiter = Limiter(**limiter_args)
-        app = Starlette(debug=True)
-        app.state.limiter = limiter
-        app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
-        app.add_middleware(SlowAPIMiddleware)
+    @pytest.fixture(params=[SlowAPIMiddleware, SlowAPIASGIMiddleware])
+    def build_starlette_app(self, request):
+        def _factory(config={}, **limiter_args):
+            limiter_args.setdefault("key_func", get_remote_address)
+            limiter = Limiter(**limiter_args)
+            app = Starlette(debug=True)
+            app.state.limiter = limiter
+            app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+            app.add_middleware(request.param)
 
-        mock_handler = mock.Mock()
-        mock_handler.level = logging.INFO
-        limiter.logger.addHandler(mock_handler)
-        return app, limiter
+            mock_handler = mock.Mock()
+            mock_handler.level = logging.INFO
+            limiter.logger.addHandler(mock_handler)
+            return app, limiter
 
-    def build_fastapi_app(self, config={}, **limiter_args):
-        limiter_args.setdefault("key_func", get_remote_address)
-        limiter = Limiter(**limiter_args)
-        app = FastAPI()
-        app.state.limiter = limiter
-        app.add_middleware(SlowAPIMiddleware)
+        return _factory
 
-        mock_handler = mock.Mock()
-        mock_handler.level = logging.INFO
-        limiter.logger.addHandler(mock_handler)
-        return app, limiter
+    @pytest.fixture(params=[SlowAPIMiddleware, SlowAPIASGIMiddleware])
+    def build_fastapi_app(self, request):
+        def _factory(config={}, **limiter_args):
+            limiter_args.setdefault("key_func", get_remote_address)
+            limiter = Limiter(**limiter_args)
+            app = FastAPI()
+            app.state.limiter = limiter
+            app.add_middleware(request.param)
+
+            mock_handler = mock.Mock()
+            mock_handler.level = logging.INFO
+            limiter.logger.addHandler(mock_handler)
+            return app, limiter
+
+        return _factory

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -9,8 +9,8 @@ from tests import TestSlowapi
 
 
 class TestDecorators(TestSlowapi):
-    def test_single_decorator(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_single_decorator(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t1")
         @limiter.limit("5/minute")
@@ -22,8 +22,8 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
 
-    def test_single_decorator_with_headers(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+    def test_single_decorator_with_headers(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
         @app.get("/t1")
         @limiter.limit("5/minute")
@@ -39,8 +39,8 @@ class TestDecorators(TestSlowapi):
             )
             assert response.headers.get("Retry-After") is not None if i < 5 else True
 
-    def test_single_decorator_not_response(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_single_decorator_not_response(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t1")
         @limiter.limit("5/minute")
@@ -52,8 +52,8 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
 
-    def test_single_decorator_not_response_with_headers(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+    def test_single_decorator_not_response_with_headers(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
         @app.get("/t1")
         @limiter.limit("5/minute")
@@ -69,8 +69,8 @@ class TestDecorators(TestSlowapi):
             )
             assert response.headers.get("Retry-After") is not None if i < 5 else True
 
-    def test_multiple_decorators(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_multiple_decorators(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t1")
         @limiter.limit(
@@ -94,8 +94,8 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
-    def test_multiple_decorators_not_response(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_multiple_decorators_not_response(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t1")
         @limiter.limit(
@@ -119,8 +119,8 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
-    def test_multiple_decorators_not_response_with_headers(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+    def test_multiple_decorators_not_response_with_headers(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
         @app.get("/t1")
         @limiter.limit(
@@ -144,8 +144,8 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
-    def test_endpoint_missing_request_param(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_endpoint_missing_request_param(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         with pytest.raises(Exception) as exc_info:
 
@@ -158,8 +158,8 @@ class TestDecorators(TestSlowapi):
             r"""^No "request" or "websocket" argument on function .*"""
         )
 
-    def test_endpoint_missing_request_param_sync(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_endpoint_missing_request_param_sync(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         with pytest.raises(Exception) as exc_info:
 
@@ -172,8 +172,8 @@ class TestDecorators(TestSlowapi):
             r"""^No "request" or "websocket" argument on function .*"""
         )
 
-    def test_endpoint_request_param_invalid(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_endpoint_request_param_invalid(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t4")
         @limiter.limit("5/minute")
@@ -187,8 +187,8 @@ class TestDecorators(TestSlowapi):
             r"""parameter `request` must be an instance of starlette.requests.Request"""
         )
 
-    def test_endpoint_response_param_invalid(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+    def test_endpoint_response_param_invalid(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
         @app.get("/t4")
         @limiter.limit("5/minute")
@@ -202,8 +202,8 @@ class TestDecorators(TestSlowapi):
             r"""parameter `response` must be an instance of starlette.responses.Response"""
         )
 
-    def test_endpoint_request_param_invalid_sync(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_endpoint_request_param_invalid_sync(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t5")
         @limiter.limit("5/minute")
@@ -217,8 +217,8 @@ class TestDecorators(TestSlowapi):
             r"""parameter `request` must be an instance of starlette.requests.Request"""
         )
 
-    def test_endpoint_response_param_invalid_sync(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
+    def test_endpoint_response_param_invalid_sync(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
         @app.get("/t5")
         @limiter.limit("5/minute")
@@ -232,7 +232,7 @@ class TestDecorators(TestSlowapi):
             r"""parameter `response` must be an instance of starlette.responses.Response"""
         )
 
-    def test_dynamic_limit_provider_depending_on_key(self):
+    def test_dynamic_limit_provider_depending_on_key(self, build_fastapi_app):
         def custom_key_func(request: Request):
             if request.headers.get("TOKEN") == "secret":
                 return "admin"
@@ -243,7 +243,7 @@ class TestDecorators(TestSlowapi):
                 return "10/minute"
             return "5/minute"
 
-        app, limiter = self.build_fastapi_app(key_func=custom_key_func)
+        app, limiter = build_fastapi_app(key_func=custom_key_func)
 
         @app.get("/t1")
         @limiter.limit(dynamic_limit_provider)
@@ -259,11 +259,11 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t1", headers={"TOKEN": "secret"})
             assert response.status_code == 200 if i < 10 else 429
 
-    def test_disabled_limiter(self):
+    def test_disabled_limiter(self, build_fastapi_app):
         """
         Check that the limiter does nothing if disabled (both sync and async)
         """
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr, enabled=False)
+        app, limiter = build_fastapi_app(key_func=get_ipaddr, enabled=False)
 
         @app.get("/t1")
         @limiter.limit("5/minute")

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -292,8 +292,8 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t3")
             assert response.status_code == 200
 
-    def test_cost(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_cost(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t1")
         @limiter.limit("50/minute", cost=10)
@@ -313,8 +313,8 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t2")
             assert response.status_code == 200 if i < 3 else 429
 
-    def test_callable_cost(self):
-        app, limiter = self.build_fastapi_app(key_func=get_ipaddr)
+    def test_callable_cost(self, build_fastapi_app):
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
 
         @app.get("/t1")
         @limiter.limit("50/minute", cost=lambda request: int(request.headers["foo"]))

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -258,8 +258,8 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
-    def test_cost(self):
-        app, limiter = self.build_starlette_app(key_func=get_ipaddr)
+    def test_cost(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr)
 
         @limiter.limit("50/minute", cost=10)
         async def t1(request: Request):
@@ -289,8 +289,8 @@ class TestDecorators(TestSlowapi):
             else:
                 assert "error" in response.json()
 
-    def test_callable_cost(self):
-        app, limiter = self.build_starlette_app(key_func=get_ipaddr)
+    def test_callable_cost(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr)
 
         @limiter.limit("50/minute", cost=lambda request: int(request.headers["foo"]))
         async def t1(request: Request):

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -10,8 +10,8 @@ from tests import TestSlowapi
 
 
 class TestDecorators(TestSlowapi):
-    def test_single_decorator_async(self):
-        app, limiter = self.build_starlette_app(key_func=get_ipaddr)
+    def test_single_decorator_async(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr)
 
         @limiter.limit("5/minute")
         async def t1(request: Request):
@@ -26,8 +26,8 @@ class TestDecorators(TestSlowapi):
             if i < 5:
                 assert response.text == "test"
 
-    def test_single_decorator_sync(self):
-        app, limiter = self.build_starlette_app(key_func=get_ipaddr)
+    def test_single_decorator_sync(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr)
 
         @limiter.limit("5/minute")
         def t1(request: Request):
@@ -42,8 +42,8 @@ class TestDecorators(TestSlowapi):
             if i < 5:
                 assert response.text == "test"
 
-    def test_shared_decorator(self):
-        app, limiter = self.build_starlette_app(key_func=get_ipaddr)
+    def test_shared_decorator(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr)
 
         shared_lim = limiter.shared_limit("5/minute", "somescope")
 
@@ -65,8 +65,8 @@ class TestDecorators(TestSlowapi):
         # the shared limit has already been hit via t1
         assert client.get("/t2").status_code == 429
 
-    def test_multiple_decorators(self):
-        app, limiter = self.build_starlette_app(key_func=get_ipaddr)
+    def test_multiple_decorators(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr)
 
         @limiter.limit("10 per minute", lambda: "test")
         @limiter.limit("5/minute")  # per ip as per default key_func
@@ -89,10 +89,8 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
-    def test_multiple_decorators_with_headers(self):
-        app, limiter = self.build_starlette_app(
-            key_func=get_ipaddr, headers_enabled=True
-        )
+    def test_multiple_decorators_with_headers(self, build_starlette_app):
+        app, limiter = build_starlette_app(key_func=get_ipaddr, headers_enabled=True)
 
         @limiter.limit("10 per minute", lambda: "test")
         @limiter.limit("5/minute")  # per ip as per default key_func
@@ -116,8 +114,8 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
-    def test_headers_no_breach(self):
-        app, limiter = self.build_starlette_app(
+    def test_headers_no_breach(self, build_starlette_app):
+        app, limiter = build_starlette_app(
             headers_enabled=True, key_func=get_remote_address
         )
 
@@ -149,8 +147,8 @@ class TestDecorators(TestSlowapi):
 
                 assert resp.headers.get("Retry-After") == str(1)
 
-    def test_headers_breach(self):
-        app, limiter = self.build_starlette_app(
+    def test_headers_breach(self, build_starlette_app):
+        app, limiter = build_starlette_app(
             headers_enabled=True, key_func=get_remote_address
         )
 
@@ -172,10 +170,10 @@ class TestDecorators(TestSlowapi):
                 )
                 assert resp.headers.get("Retry-After") == str(int(50))
 
-    def test_retry_after(self):
+    def test_retry_after(self, build_starlette_app):
         # FIXME: this test is not actually running!
 
-        app, limiter = self.build_starlette_app(
+        app, limiter = build_starlette_app(
             headers_enabled=True, key_func=get_remote_address
         )
 
@@ -193,8 +191,8 @@ class TestDecorators(TestSlowapi):
                 resp = cli.get("/t1")
                 assert resp.status_code == 200
 
-    def test_exempt_decorator(self):
-        app, limiter = self.build_starlette_app(
+    def test_exempt_decorator(self, build_starlette_app):
+        app, limiter = build_starlette_app(
             headers_enabled=True,
             key_func=get_remote_address,
             default_limits=["1/minute"],
@@ -235,8 +233,8 @@ class TestDecorators(TestSlowapi):
             assert resp2.status_code == 200
 
     # todo: more tests - see https://github.com/alisaifee/flask-limiter/blob/55df08f14143a7e918fc033067a494248ab6b0c5/tests/test_decorators.py#L187
-    def test_default_and_decorator_limit_merging(self):
-        app, limiter = self.build_starlette_app(
+    def test_default_and_decorator_limit_merging(self, build_starlette_app):
+        app, limiter = build_starlette_app(
             key_func=lambda: "test", default_limits=["10/minute"]
         )
 


### PR DESCRIPTION
fix https://github.com/laurentS/slowapi/issues/98

Might be easier for people reviewing to explain the different commits:
- first commit adds the new ASGI middleware
- second one update tests so that it test both the HTTP and ASGI middlewares (using pytest parametrize and fixtures)
- third one is a refactoring commit, to avoid duplicating too much code between the HTTP and the ASGI middleware

Might be easier to first review the first two commits, then the refactoring one (to avoid seeing too many changes at once)

Let me know what do you think about this :smile:

Note: maybe I could do a bit of refactoring  between `_inject_headers` and `_inject_asgi_headers` as well ?