### PR TITLE
new: :sparkles: add key_style parameter to choose between endpoint or url

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Literal,
     List,
     Optional,
     Set,
@@ -33,6 +32,7 @@ from starlette.config import Config
 from starlette.datastructures import MutableHeaders
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
+from typing_extensions import Literal
 
 from .errors import RateLimitExceeded
 from .wrappers import Limit, LimitGroup

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -339,7 +339,7 @@ class TestDecorators(TestSlowapi):
     @pytest.mark.parametrize(
         "key_style, expected_key",
         [
-            ("url", "LIMITER/mock//t1/1/1/minute"),
+            ("url", "LIMITER/mock//t1/param_one/1/1/minute"),
             (
                 "endpoint",
                 "LIMITER/mock/tests.test_fastapi_extension.t1_func/1/1/minute",
@@ -349,11 +349,24 @@ class TestDecorators(TestSlowapi):
     def test_key_style(self, build_fastapi_app, key_style, expected_key):
         app, limiter = build_fastapi_app(key_func=lambda: "mock", key_style=key_style)
 
-        @app.get("/t1")
+        @app.get("/t1/{my_param}")
         @limiter.limit("1/minute")
-        async def t1_func(request: Request):
+        async def t1_func(my_param: str, request: Request):
             return PlainTextResponse("test")
 
         client = TestClient(app)
-        client.get("/t1", headers={"foo": "10"})
-        assert limiter._storage.get(expected_key) == 1
+        client.get("/t1/param_one")
+        second_call = client.get("/t1/param_two")
+        # with the "url" key_style, since the `my_param` value changed, the storage key is different
+        # meaning it should not raise any RateLimitExceeded error.
+        if key_style == "url":
+            assert second_call.status_code == 200
+            # also assert that we counted only one request on the expected key
+            assert limiter._storage.get(expected_key) == 1
+        # However, with the `endpoint` key_style, it will use the function name (e.g: "t1_func")
+        # meaning it will raise a RateLimitExceeded error, because no matter the parameter value
+        # it will share the limitations.
+        elif key_style == "endpoint":
+            assert second_call.status_code == 429
+            # check that we counted 2 requests, even though we had a different value for "my_param"
+            assert limiter._storage.get(expected_key) == 2

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -347,9 +347,7 @@ class TestDecorators(TestSlowapi):
         ],
     )
     def test_key_style(self, build_fastapi_app, key_style, expected_key):
-        app, limiter = build_fastapi_app(
-            key_func=lambda: "mock", key_style=key_style
-        )
+        app, limiter = build_fastapi_app(key_func=lambda: "mock", key_style=key_style)
 
         @app.get("/t1")
         @limiter.limit("1/minute")

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -346,8 +346,8 @@ class TestDecorators(TestSlowapi):
             ),
         ],
     )
-    def test_key_style(self, key_style, expected_key):
-        app, limiter = self.build_fastapi_app(
+    def test_key_style(self, build_fastapi_app, key_style, expected_key):
+        app, limiter = build_fastapi_app(
             key_func=lambda: "mock", key_style=key_style
         )
 

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -334,9 +334,7 @@ class TestDecorators(TestSlowapi):
         ],
     )
     def test_key_style(self, build_starlette_app, key_style, expected_key):
-        app, limiter = build_starlette_app(
-            key_func=lambda: "mock", key_style=key_style
-        )
+        app, limiter = build_starlette_app(key_func=lambda: "mock", key_style=key_style)
 
         @limiter.limit("1/minute")
         async def t1_func(request: Request):

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -333,8 +333,8 @@ class TestDecorators(TestSlowapi):
             ),
         ],
     )
-    def test_key_style(self, key_style, expected_key):
-        app, limiter = self.build_starlette_app(
+    def test_key_style(self, build_starlette_app, key_style, expected_key):
+        app, limiter = build_starlette_app(
             key_func=lambda: "mock", key_style=key_style
         )
 

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -324,16 +324,10 @@ class TestDecorators(TestSlowapi):
                 assert "error" in response.json()
 
     @pytest.mark.parametrize(
-        "key_style, expected_key",
-        [
-            ("url", "LIMITER/mock//t1/param_one/1/1/minute"),
-            (
-                "endpoint",
-                "LIMITER/mock/tests.test_starlette_extension.t1_func/1/1/minute",
-            ),
-        ],
+        "key_style",
+        ["url", "endpoint"],
     )
-    def test_key_style(self, build_starlette_app, key_style, expected_key):
+    def test_key_style(self, build_starlette_app, key_style):
         app, limiter = build_starlette_app(key_func=lambda: "mock", key_style=key_style)
 
         @limiter.limit("1/minute")
@@ -349,12 +343,17 @@ class TestDecorators(TestSlowapi):
         # meaning it should not raise any RateLimitExceeded error.
         if key_style == "url":
             assert second_call.status_code == 200
-            # also assert that we counted only one request on the expected key
-            assert limiter._storage.get(expected_key) == 1
+            assert limiter._storage.get("LIMITER/mock//t1/param_one/1/1/minute") == 1
+            assert limiter._storage.get("LIMITER/mock//t1/param_two/1/1/minute") == 1
         # However, with the `endpoint` key_style, it will use the function name (e.g: "t1_func")
         # meaning it will raise a RateLimitExceeded error, because no matter the parameter value
         # it will share the limitations.
         elif key_style == "endpoint":
             assert second_call.status_code == 429
             # check that we counted 2 requests, even though we had a different value for "my_param"
-            assert limiter._storage.get(expected_key) == 2
+            assert (
+                limiter._storage.get(
+                    "LIMITER/mock/tests.test_starlette_extension.t1_func/1/1/minute"
+                )
+                == 2
+            )


### PR DESCRIPTION
Hi !
I'm currently migrating an application from flask to fast-api. This application was using flask-limiter so we chose to go with slowapi to ease-out how transition.
However, by testing the behavior I found a breaking change:
- by default, flask use the route function name as part of the storage key, while slowapi uses the route endpoint.

At first, it looks like nothing, but this means the behavior change:

## Example:
```python
# flask
@app.get("/my_endpoint/<name>")
def my_endpoint_func(name):
     ...
  
# fastapi
@app.get("/my_endpoint/{name}")
def my_endpoint_func(name):
    ...
```

Calling `/my_endpoint/1` on flask would use `LIMITER/{key_func_result}/{module}.my_endpoint_func/1/1/minute` as a key, while slowapi would use `LIMITER/{key_func_result}//my_endpoint/1/1/1/minute`.

This means that, on flask, calling `/my_endpoint/1` and `/my_endpoint/2` would share the same limitations, while on slowapi it won't, since the `/1` & `/2` are part of the storage key.

## Solution:
This PR adds a `key_style` parameter to the Limiter `__init__` func. (key_style can be either `url` or `endpoint`.
- when using `"url"` (default value) keep the current behavior using the route endpoint.
- when using `"endpoint"`, use the function name instead, so that it matches the fastAPI behavior.

NOTES:
- this PR includes some tests, that might help understand the difference visually
- also updated the docs

This PR should not break the current behavior because of the default value, but add an option for people needing the behavior found in flask-limiter.
