### PR TITLE
XFF Standard `X-Forwarded-For` header

### DIFF
--- a/slowapi/util.py
+++ b/slowapi/util.py
@@ -10,6 +10,8 @@ def get_ipaddr(request: Request) -> str:
     """
     if "X_FORWARDED_FOR" in request.headers:
         return request.headers["X_FORWARDED_FOR"]
+    elif "X-Forwarded-For" in request.headers:
+        return request.headers["X-Forwarded-For"]
     else:
         return request.client.host or "127.0.0.1"
 


### PR DESCRIPTION
I would propose deprecating the other non-standard header in the future.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

Also the default used by Load Balancers.