### PR TITLE
chore: prepare release 0.1.8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
       uses: snok/install-poetry@v1
       with:
         # Version of Poetry to use
-        version: 1.2.2
+        version: 1.4.2
     - name: Install dependencies
       run: |
         poetry install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.1.8] - 2023-04-07
+
+### Added
+
+- Loosen restriction on the limits dependency (thanks @sanders41)
+- Fix redis install error (thanks @sanders41)
+- Add Python 3.11 support (thanks @sanders41)
+
+
 ## [0.1.7] - 2022-11-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slowapi"
-version = "0.1.7"
+version = "0.1.8"
 description = "A rate limiting extension for Starlette and Fastapi"
 authors = ["Laurent Savaete <laurent@where.tf>"]
 license = "MIT"


### PR DESCRIPTION
This PR prepares the release `0.1.8` 