### PR TITLE
feat: allow Requests to be sent to exempt_when

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.1.10] - 2024-06-04
+
+### Changed
+
+- Breaking: allow usage of the request object in the except_when function (thanks @colin99d)
+
 ## [0.1.9] - 2024-02-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Breaking: allow usage of the request object in the except_when function (thanks @colin99d)
+- Breaking change: allow usage of the request object in the except_when function (thanks @colin99d)
 
 ## [0.1.9] - 2024-02-05
 

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -1,6 +1,7 @@
 """
 The starlette extension to rate-limit requests
 """
+
 import asyncio
 import functools
 import inspect
@@ -734,7 +735,8 @@ class Limiter:
                         if not isinstance(response, Response):
                             # get the response object from the decorated endpoint function
                             self._inject_headers(
-                                kwargs.get("response"), request.state.view_rate_limit  # type: ignore
+                                kwargs.get("response"),
+                                request.state.view_rate_limit,  # type: ignore
                             )
                         else:
                             self._inject_headers(
@@ -766,7 +768,8 @@ class Limiter:
                         if not isinstance(response, Response):
                             # get the response object from the decorated endpoint function
                             self._inject_headers(
-                                kwargs.get("response"), request.state.view_rate_limit  # type: ignore
+                                kwargs.get("response"),
+                                request.state.view_rate_limit,  # type: ignore
                             )
                         else:
                             self._inject_headers(
@@ -803,7 +806,7 @@ class Limiter:
         * **error_message**: string (or callable that returns one) to override the
          error message used in the response.
         * **exempt_when**: function returning a boolean indicating whether to exempt
-        the route from the limit
+        the route from the limit. This function can optionally use a Request object.
         * **cost**: integer (or callable that returns one) which is the cost of a hit
         * **override_defaults**: whether to override the default limits (default: True)
         """

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -735,8 +735,8 @@ class Limiter:
                         if not isinstance(response, Response):
                             # get the response object from the decorated endpoint function
                             self._inject_headers(
-                                kwargs.get("response"),
-                                request.state.view_rate_limit,  # type: ignore
+                                kwargs.get("response"),  # type: ignore
+                                request.state.view_rate_limit,
                             )
                         else:
                             self._inject_headers(

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -482,7 +482,7 @@ class Limiter:
         limit_for_header = None
         for lim in limits:
             limit_scope = lim.scope or endpoint
-            if lim.is_exempt:
+            if lim.is_exempt(request):
                 continue
             if lim.methods is not None and request.method.lower() not in lim.methods:
                 continue
@@ -699,11 +699,9 @@ class Limiter:
             else:
                 self._route_limits.setdefault(name, []).extend(static_limits)
 
-            connection_type: Optional[str] = None
             sig = inspect.signature(func)
             for idx, parameter in enumerate(sig.parameters.values()):
                 if parameter.name == "request" or parameter.name == "websocket":
-                    connection_type = parameter.name
                     break
             else:
                 raise Exception(

--- a/slowapi/wrappers.py
+++ b/slowapi/wrappers.py
@@ -32,7 +32,7 @@ class Limit(object):
         self.cost = cost
         self.override_defaults = override_defaults
 
-    def is_exempt(self, request: Request) -> bool:
+    def is_exempt(self, request: Optional[Request] = None) -> bool:
         """
         Check if the limit is exempt.
 
@@ -45,7 +45,7 @@ class Limit(object):
             return False
         params = inspect.signature(self.exempt_when).parameters
         param_len = len(params)
-        if param_len == 1:
+        if param_len == 1 and request:
             return self.exempt_when(request)
         return self.exempt_when()
 

--- a/slowapi/wrappers.py
+++ b/slowapi/wrappers.py
@@ -29,7 +29,9 @@ class Limit(object):
         self.methods = methods
         self.error_message = error_message
         self.exempt_when = exempt_when
-        self._exempt_when_takes_request = len(inspect.signature(self.exempt_when).parameters) == 1
+        self._exempt_when_takes_request = (
+            len(inspect.signature(self.exempt_when).parameters) == 1
+        )
         self.cost = cost
         self.override_defaults = override_defaults
 

--- a/slowapi/wrappers.py
+++ b/slowapi/wrappers.py
@@ -29,6 +29,7 @@ class Limit(object):
         self.methods = methods
         self.error_message = error_message
         self.exempt_when = exempt_when
+        self._exempt_when_takes_request = len(inspect.signature(self.exempt_when).parameters) == 1
         self.cost = cost
         self.override_defaults = override_defaults
 
@@ -43,9 +44,7 @@ class Limit(object):
         """
         if self.exempt_when is None:
             return False
-        params = inspect.signature(self.exempt_when).parameters
-        param_len = len(params)
-        if param_len == 1 and request:
+        if self._exempt_when_takes_request and request:
             return self.exempt_when(request)
         return self.exempt_when()
 

--- a/slowapi/wrappers.py
+++ b/slowapi/wrappers.py
@@ -35,6 +35,10 @@ class Limit(object):
     def is_exempt(self, request: Request) -> bool:
         """
         Check if the limit is exempt.
+
+        ** parameter **
+        * **request**: the request object
+
         Return True to exempt the route from the limit.
         """
         if self.exempt_when is None:

--- a/slowapi/wrappers.py
+++ b/slowapi/wrappers.py
@@ -30,7 +30,8 @@ class Limit(object):
         self.error_message = error_message
         self.exempt_when = exempt_when
         self._exempt_when_takes_request = (
-            len(inspect.signature(self.exempt_when).parameters) == 1
+            self.exempt_when
+            and len(inspect.signature(self.exempt_when).parameters) == 1
         )
         self.cost = cost
         self.override_defaults = override_defaults


### PR DESCRIPTION
Creates a way to use the request object in the exempt_when function.

Now allows functions like this to be used: 

```
def test_exempt(x) -> bool:
    print(x.headers.get("User-Agent"))
    return False
```

Fixes #155

Lines 702 and 706 were automatically removed by my linter because they are unused. Let me know if you want them back. Also, let me know if you want ruff added to CI for code linting.