### PR TITLE
fix: limit_value typehint for limit function

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -778,7 +778,7 @@ class Limiter:
 
     def limit(
         self,
-        limit_value: Union[str, Callable[[str], str]],
+        limit_value: StrOrCallableStr,
         key_func: Optional[Callable[..., str]] = None,
         per_method: bool = False,
         methods: Optional[List[str]] = None,


### PR DESCRIPTION
The limit_decorator function takes a strOrCallableStr for its limit_value parameter. Update Limiter.limit function's lmit_value typehint to follow the same type hints as to pass to the limit_decorator_function