### PR TITLE
chore(extensions) fix shared_limit typing

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -818,7 +818,7 @@ class Limiter:
 
     def shared_limit(
         self,
-        limit_value: Union[str, Callable[[str], str]],
+        limit_value: StrOrCallableStr,
         scope: StrOrCallableStr,
         key_func: Optional[Callable[..., str]] = None,
         error_message: Optional[str] = None,


### PR DESCRIPTION
Hello there 👋🏻 

We are using this repository and `mypy` raised an issue on `shared_limit` because the callable we were giving it for `limit_value` was just a `Callable[[None], str]]`

Using the `StrOrCallableStr` that already here fixes the issue 🙂 

@laurentS let me know if it's ok for you !