### PR TITLE
Added clarification about default config_filename in Limiter

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,6 +56,11 @@ You can always switch this during the lifetime of the limiter:
     limiter.enabled = False
 ```
 
+#### Note: config file is set to ".env" by default. Therefore, if you have a .env file setup for something else already, specify the config_filename parameter
+```python
+limiter = Limiter(key_func=get_remote_address, default_limits=["1/minute"], config_filename=".your_config_file")
+```
+
 ## Use redis as backend for the limiter
 
 ```python


### PR DESCRIPTION
Description:

- Added documentation for the Limiter function's config_filename parameter.
- Clarified that the default value is ".env" and provided guidance for specifying it when a different .env file exists.

I encountered a UnicodeDecodeError related to the default config_filename in SlowAPI's Limiter function. After investigating SlowAPI's source code, I found that '.env' is used as the default config_filename. This PR aims to prevent similar issues by documenting this default behaviour.

Please review and consider merging.

Thank you for maintaining this project.

Regards,
FloareDor