### PR TITLE
fix: only pass .env as default to starlette config if it exists

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -157,7 +157,9 @@ class Limiter:
 
         dotenv_file_exists = os.path.isfile(".env")
         self.app_config = Config(
-            ".env" if dotenv_file_exists and config_filename is None else config_filename
+            ".env"
+            if dotenv_file_exists and config_filename is None
+            else config_filename
         )
 
         self.enabled = enabled

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 import itertools
 import logging
+import os
 import time
 from datetime import datetime
 from email.utils import formatdate, parsedate_to_datetime
@@ -154,8 +155,9 @@ class Limiter:
 
         self.logger = logging.getLogger("slowapi")
 
+        dotenv_file_exists = os.path.isfile(".env")
         self.app_config = Config(
-            config_filename if config_filename is not None else ".env"
+            ".env" if dotenv_file_exists and config_filename is None else config_filename
         )
 
         self.enabled = enabled


### PR DESCRIPTION
The latest version of `starlette` [throws if the provided config file doesn't exist](https://github.com/encode/starlette/pull/2422/files). 

This PR changes the `Limiter` class's `__init__` function to pass `".env"` to `Config` only if it exists. This should preserve existing behavior while preventing guaranteed exceptions.