### PR TITLE
chore: prepare 0.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.1.9] - 2024-02-05
+
+### Added
+
+- Fix `limit_value` typehint in `limit()` function (thanks @PookieBuns)
+- Fix `limit_value` typehint in `shared_limit()` function (thanks @aberlioz)
+- Only pass `".env"` to starlette `Config` if `".env"` file exists (thanks @daniellok-db)
+
 ## [0.1.8] - 2023-04-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slowapi"
-version = "0.1.8"
+version = "0.1.9"
 description = "A rate limiting extension for Starlette and Fastapi"
 authors = ["Laurent Savaete <laurent@where.tf>"]
 license = "MIT"


### PR DESCRIPTION
This PR prepares the 0.1.9 release. I think I included notes for [all the commits since 0.1.8](https://github.com/laurentS/slowapi/pulls?q=is%3Apr+is%3Aclosed), but let me know if I've missed any!