### PR TITLE
Enhance log message to include the endpoint when limit is skipped

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -518,7 +518,9 @@ class Limiter:
                     break
             else:
                 self.logger.error(
-                    "Skipping limit: %s. Empty value found in parameters.", lim.limit
+                    "Skipping limit: %s at endpoint: %s. Empty value found in parameters.",
+                    lim.limit,
+                    limit_scope
                 )
                 continue
         # keep track of which limit was hit, to be picked up for the response header


### PR DESCRIPTION
When a limit is skipped, we cannot tell the endpoint that was tied to the request. This enhances the log statement to include the endpoint. 