### PR TITLE
Change .warn to .warning Py3.11 deprecation

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -632,7 +632,7 @@ class Limiter:
             if isinstance(e, RateLimitExceeded):
                 raise
             if self._in_memory_fallback_enabled and not self._storage_dead:
-                self.logger.warn(
+                self.logger.warning(
                     "Rate limit storage unreachable - falling back to"
                     " in-memory storage"
                 )


### PR DESCRIPTION
Nit to fix warning:
```
python3.11/site-packages/slowapi/extension.py:631: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self.logger.warn(
```