### PR TITLE
chore: prepare 0.1.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Breaking change: allow usage of the request object in the except_when function (thanks @colin99d)
+- Added more test exemption logic (thanks @colin99)
+- Fix logger warning for Python 3.11 deprecation  (thanks @kevin868)
 
 ## [0.1.9] - 2024-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Breaking change: allow usage of the request object in the except_when function (thanks @colin99d)
+- Added: allow usage of the request object in the except_when function (thanks @colin99d)
 - Added more test exemption logic (thanks @colin99)
 - Fix logger warning for Python 3.11 deprecation  (thanks @kevin868)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slowapi"
-version = "0.1.9"
+version = "0.1.10"
 description = "A rate limiting extension for Starlette and Fastapi"
 authors = ["Laurent Savaete <laurent@where.tf>"]
 license = "MIT"

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -487,8 +487,12 @@ class Limiter:
         limit_for_header = None
         for lim in limits:
             limit_scope = lim.scope or endpoint
-            if lim.is_exempt(request):
+            if getattr(lim, "_exempt_when_takes_request", False):
+                if lim.is_exempt(request):
+                    continue
+            elif lim.is_exempt():
                 continue
+
             if lim.methods is not None and request.method.lower() not in lim.methods:
                 continue
             if lim.per_method:


### PR DESCRIPTION
This PR prepares the 0.1.10 release. Added notes for all remaining distinct commits since 0.1.9.

Not sure 0.2.0 would be more appropriate given the breaking changes. Another option could be to change the implementation from #160 to be backwards compatible using `inspect`. Let me know what you think @laurentS then I'd be happy to help.

As per: https://github.com/laurentS/slowapi/pull/160#issuecomment-2298372438