### PR TITLE
fix typing error when adding the `_rate_limit_exceeded_handler`

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,7 +8,7 @@ The tests show a lot of different use cases that are not all covered here.
 
 ```python
     from starlette.applications import Starlette
-    from slowapi import Limiter, _rate_limit_exceeded_handler
+    from slowapi import Limiter, rate_limit_exceeded_handler
     from slowapi.util import get_remote_address
     from slowapi.middleware import SlowAPIMiddleware
     from slowapi.errors import RateLimitExceeded
@@ -16,7 +16,7 @@ The tests show a lot of different use cases that are not all covered here.
     limiter = Limiter(key_func=get_remote_address, default_limits=["1/minute"])
     app = Starlette()
     app.state.limiter = limiter
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
     app.add_middleware(SlowAPIMiddleware)
 
     # this will be limited by the default_limits

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,14 +20,14 @@ $ pip install slowapi
     from starlette.applications import Starlette
     from starlette.responses import PlainTextResponse
     from starlette.requests import Request
-    from slowapi import Limiter, _rate_limit_exceeded_handler
+    from slowapi import Limiter, rate_limit_exceeded_handler
     from slowapi.util import get_remote_address
     from slowapi.errors import RateLimitExceeded
 
     limiter = Limiter(key_func=get_remote_address)
     app = Starlette()
     app.state.limiter = limiter
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
     @limiter.limit("5/minute")
     async def homepage(request: Request):
@@ -42,14 +42,14 @@ The above app will have a route `t1` that will accept up to 5 requests per minut
 
 ```python
     from fastapi import FastAPI, Request, Response
-    from slowapi import Limiter, _rate_limit_exceeded_handler
+    from slowapi import Limiter, rate_limit_exceeded_handler
     from slowapi.util import get_remote_address
     from slowapi.errors import RateLimitExceeded
 
     limiter = Limiter(key_func=get_remote_address)
     app = FastAPI()
     app.state.limiter = limiter
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
     # Note: the route decorator must be above the limit decorator, not below it
     @app.get("/home")

--- a/slowapi/__init__.py
+++ b/slowapi/__init__.py
@@ -1,3 +1,3 @@
-from .extension import Limiter, _rate_limit_exceeded_handler
+from .extension import Limiter, rate_limit_exceeded_handler, _rate_limit_exceeded_handler
 
-__all__ = ["Limiter", "_rate_limit_exceeded_handler"]
+__all__ = ["Limiter", "rate_limit_exceeded_handler", "_rate_limit_exceeded_handler"]

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -86,6 +86,13 @@ def _rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Re
     )
     return response
 
+def rate_limit_exceeded_handler(request: Request, exc: Exception) -> Response:
+    """
+    Handle rate limit exceeded exceptions.
+    """
+    if isinstance(exc, RateLimitExceeded):
+        return _rate_limit_exceeded_handler(request, exc)
+    raise exc
 
 class Limiter:
     """


### PR DESCRIPTION
1. Add new `rate_limit_exceeded_handler` that handle all the exception to fix the typing error
2. use the `_rate_limit_exceeded_handler` for the backward compitability.
3. adjust the document to reflect the changes and use the new handler.