### PR TITLE
ci: drop python 3.7 and 3.8 from CI checks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supported now:
 - redis, memcached and memory backends to track your limits (memory as a fallback)
 - support for sync and async HTTP endpoints
 - Support for shared limits across a set of routes
-
+- The library aims to support all [currently supported versions](https://devguide.python.org/versions/) of python
 
 # Limitations and known issues
 


### PR DESCRIPTION
A tiny PR to remove EOL versions of python. Not adding newer versions on purpose, to make sure we don't get extra CI failures from them. These can go into separate PRs.