### PR TITLE
Switch from asyncio to inspect for iscoroutinefunction to fix deprecation warning

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -2,7 +2,6 @@
 The starlette extension to rate-limit requests
 """
 
-import asyncio
 import functools
 import inspect
 import itertools
@@ -713,7 +712,7 @@ class Limiter:
                     f'No "request" or "websocket" argument on function "{func}"'
                 )
 
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 # Handle async request/response functions.
                 @functools.wraps(func)
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Response:
@@ -870,7 +869,7 @@ class Limiter:
 
         self._exempt_routes.add(name)
 
-        if asyncio.iscoroutinefunction(obj):
+        if inspect.iscoroutinefunction(obj):
 
             @wraps(obj)
             async def __async_inner(*a, **k):


### PR DESCRIPTION
asyncio.iscoroutinefunction is being removed in Python 3.16 and is being marked as deprecated in 3.14. This fixes the deprecation warning and future breakage.