### PR TITLE
Fix: Replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -713,7 +713,7 @@ class Limiter:
                     f'No "request" or "websocket" argument on function "{func}"'
                 )
 
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 # Handle async request/response functions.
                 @functools.wraps(func)
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Response:
@@ -870,7 +870,7 @@ class Limiter:
 
         self._exempt_routes.add(name)
 
-        if asyncio.iscoroutinefunction(obj):
+        if inspect.iscoroutinefunction(obj):
 
             @wraps(obj)
             async def __async_inner(*a, **k):


### PR DESCRIPTION
Replaces deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` as recommended by the deprecation warning.

Context:
Observed `DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16` when running tests on newer CPython versions.
