### PR TITLE
fix: handle exceptions without 'detail' attribute in error handler

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -73,13 +73,22 @@ class HEADERS:
 MAX_BACKEND_CHECKS = 5
 
 
-def _rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
+def _rate_limit_exceeded_handler(request: Request, exc: Exception) -> Response:
     """
     Build a simple JSON response that includes the details of the rate limit
     that was hit. If no limit is hit, the countdown is added to headers.
+    
+    Handles exceptions that may not have a 'detail' attribute (e.g., ConnectionError).
     """
+    # Safely get detail attribute, fallback to exception message if not available
+    if isinstance(exc, RateLimitExceeded):
+        detail = getattr(exc, 'detail', "Rate limit exceeded")
+    else:
+        # For other exceptions (e.g., ConnectionError), use exception message
+        detail = str(exc)
+    
     response = JSONResponse(
-        {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
+        {"error": f"Rate limit exceeded: {detail}"}, status_code=429
     )
     response = request.app.state.limiter._inject_headers(
         response, request.state.view_rate_limit

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -5,6 +5,7 @@ from starlette.responses import PlainTextResponse, Response
 from starlette.testclient import TestClient
 
 from slowapi.util import get_ipaddr
+from slowapi.extension import _rate_limit_exceeded_handler
 from tests import TestSlowapi
 
 
@@ -369,3 +370,54 @@ class TestDecorators(TestSlowapi):
                 )
                 == 2
             )
+
+    def test_rate_limit_exceeded_handler_with_detail(self, build_fastapi_app):
+        """Test that RateLimitExceeded exceptions with detail attribute work correctly."""
+
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
+
+        @app.get("/test")
+        @limiter.limit("1/minute")
+        async def test_endpoint(request: Request):
+            return {"message": "test"}
+
+        client = TestClient(app)
+
+        # Make first request - should succeed
+        response1 = client.get("/test")
+        assert response1.status_code == 200
+
+        # Make second request - should be rate limited
+        response2 = client.get("/test")
+        assert response2.status_code == 429
+        assert "error" in response2.json()
+        assert "Rate limit exceeded" in response2.json()["error"]
+
+    def test_rate_limit_exceeded_handler_without_detail(self, build_fastapi_app):
+        """Test that exceptions without 'detail' attribute are handled gracefully.
+        
+        This tests the fix for issue #213 where ConnectionError or other exceptions
+        without a 'detail' attribute would cause AttributeError.
+        """
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
+        client = TestClient(app)
+        
+        # Create an exception without a 'detail' attribute (simulating ConnectionError)
+        class ExceptionWithoutDetail(Exception):
+            def __init__(self):
+                super().__init__("Connection failed")
+
+        @app.get("/test")
+        async def test_endpoint(request: Request):
+            # Manually trigger the handler with an exception without detail
+            # This simulates the bug scenario from issue #213
+            exc = ExceptionWithoutDetail()
+            response = _rate_limit_exceeded_handler(request, exc)
+            return response
+
+        # Should not crash with AttributeError
+        response = client.get("/test")
+        assert response.status_code == 429
+        assert "error" in response.json()
+        assert "Rate limit exceeded" in response.json()["error"]
+        assert "Connection failed" in response.json()["error"]


### PR DESCRIPTION
## Summary

Fixes #253

Reopening of #254 - When Redis (or another storage backend) is unavailable, slowapi's error handler tries to access `exc.detail` on a `ConnectionError` exception, which doesn't have this attribute. This causes a secondary `AttributeError` that masks the original connection failure and crashes the application.

## Changes

- Modified `_rate_limit_exceeded_handler` to accept `Exception` instead of `RateLimitExceeded`
- Used `getattr(exc, 'detail', "Rate limit exceeded")` to safely access the `detail` attribute
- Added fallback logic: use default message for `RateLimitExceeded`, or `str(exc)` for other exceptions
- Added comprehensive tests for both `RateLimitExceeded` and exceptions without `detail` scenarios

## Root Cause

The error handler in `slowapi/extension.py` directly accessed `exc.detail` without checking if the attribute exists. When a `ConnectionError` (or other exception types) is raised during rate limit checking, this assumption fails because `ConnectionError` doesn't have a `detail` attribute.

## Testing

- Added test `test_rate_limit_exceeded_handler_with_detail` to verify normal `RateLimitExceeded` exceptions still work correctly
- Added test `test_rate_limit_exceeded_handler_without_detail` to verify exceptions without a `detail` attribute are handled gracefully

## Backward Compatibility

✅ No breaking changes - existing code using `RateLimitExceeded` continues to work as before
✅ Improved error handling for edge cases (connection failures)

Closes #253