### PR TITLE
chore: clarify use cases for functions in util.py

### DIFF
--- a/slowapi/util.py
+++ b/slowapi/util.py
@@ -1,5 +1,9 @@
 from starlette.requests import Request
 
+# The functions below are provided for convenience and for use in tests.
+# They are not robust, as the number of issues about them will attest, and
+# correcting them for the numerous variations of possible setups is out of
+# scope for slowapi.
 
 def get_ipaddr(request: Request) -> str:
     """


### PR DESCRIPTION
It is not clear enough that the functions provided in `util.py` are only there for illustration purposes. This PR tries to clarify this, in order to reduce the number of issues about them, which unfortunately cannot be fixed.