### PR TITLE
fix: accept a single limit string for default_limits/application_limits (fixes #239)

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -185,6 +185,16 @@ class Limiter:
         self._key_prefix = key_prefix
         self._key_style = key_style
 
+        # A bare limit string (e.g. ``default_limits="1/minute"``) is a common
+        # mistake. The loops below iterate these arguments, and iterating a
+        # string yields its characters, silently producing a set of invalid
+        # one-character limits that later crash at request time. Accept a single
+        # limit passed as a string by wrapping it in a list (#239).
+        if isinstance(default_limits, str):
+            default_limits = [default_limits]
+        if isinstance(application_limits, str):
+            application_limits = [application_limits]
+
         for limit in set(default_limits):
             self._default_limits.extend(
                 [

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -314,6 +314,38 @@ class TestDecorators(TestSlowapi):
                 == 429
             )
 
+    def test_default_limits_accepts_a_bare_string(self, build_starlette_app):
+        """A single limit may be passed as a string, not just a list (#239)."""
+        app, limiter = build_starlette_app(
+            key_func=get_remote_address, default_limits="1/minute"
+        )
+        assert len(limiter._default_limits) == 1
+
+        @app.route("/t1")
+        def t1(request: Request):
+            return PlainTextResponse("test")
+
+        with TestClient(app) as cli:
+            headers = {"X_FORWARDED_FOR": "127.0.0.20"}
+            assert cli.get("/t1", headers=headers).status_code == 200
+            assert cli.get("/t1", headers=headers).status_code == 429
+
+    def test_application_limits_accepts_a_bare_string(self, build_starlette_app):
+        """``application_limits`` may likewise be passed as a string (#239)."""
+        app, limiter = build_starlette_app(
+            key_func=get_remote_address, application_limits="1/minute"
+        )
+        assert len(limiter._application_limits) == 1
+
+        @app.route("/t1")
+        def t1(request: Request):
+            return PlainTextResponse("test")
+
+        with TestClient(app) as cli:
+            headers = {"X_FORWARDED_FOR": "127.0.0.21"}
+            assert cli.get("/t1", headers=headers).status_code == 200
+            assert cli.get("/t1", headers=headers).status_code == 429
+
     def test_cost(self, build_starlette_app):
         app, limiter = build_starlette_app(key_func=get_ipaddr)
 


### PR DESCRIPTION
## Summary

`Limiter(default_limits="1/minute")` — passing a single limit as a string rather than a list — crashes when a limit is hit:

```
AttributeError: 'ValueError' object has no attribute 'detail'
```

`__init__` iterates `default_limits` (and `application_limits`), and iterating a string yields its characters, so `"1/minute"` becomes eight invalid one-character limits (`{'1', '/', 'm', 'i', ...}`). At request time each fails to parse; the resulting `ValueError` is then routed to the rate-limit handler, which expects a `RateLimitExceeded` and reads `.detail` — masking the real cause.

## Fix

Coerce a bare string to a single-element list for both `default_limits` and `application_limits`. This is the coercion the issue suggested, and matches the "string or list of strings" the docstring already advertises.

## Tests

Added regression tests (run across all three middleware/handler combinations) asserting that a string `default_limits`/`application_limits` stores exactly one limit and is enforced (200 then 429) instead of crashing. Full local suite: 109 passed.
