### PR TITLE
fix: Misleading loading order of kwargs vs. args

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The documentation is on [read the docs](https://slowapi.readthedocs.io/en/latest
 `slowapi` is available from [pypi](https://pypi.org/project/slowapi/) so you can install it as usual:
 
 ```
-$ pip install slowapi
+pip install slowapi
 ```
 
 # Features
@@ -34,17 +34,17 @@ Supported now:
   * The `request` argument must be explicitly passed to your endpoint, or `slowapi` won't be able to hook into it. In other words, write:
 
 ```python
-    @limiter.limit("5/minute")
-    async def myendpoint(request: Request)
-        pass
+@limiter.limit("5/minute")
+async def myendpoint(request: Request)
+    pass
 ```
 
 and not:
 
 ```python
-    @limiter.limit("5/minute")
-    async def myendpoint()
-        pass
+@limiter.limit("5/minute")
+async def myendpoint()
+    pass
 ```
 
   * `websocket` endpoints are not supported yet.
@@ -56,12 +56,12 @@ PRs are more than welcome! Please include tests for your changes :)
 The package uses [poetry](https://python-poetry.org) to manage dependencies. To setup your dev env:
 
 ```bash
-$ poetry install
+poetry install
 ```
 
 To run the tests:
 ```bash
-$ pytest
+pytest
 ```
 
 # Credits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slowapi"
-version = "0.1.10"
+version = "0.1.11"
 description = "A rate limiting extension for Starlette and Fastapi"
 authors = ["Laurent Savaete <laurent@where.tf>"]
 license = "MIT"

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -723,7 +723,9 @@ class Limiter:
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Response:
                     # get the request object from the decorated endpoint function
                     if self.enabled:
-                        request = kwargs.get("request", args[idx] if args else None)
+                        request = kwargs.get("request")
+                        if not request:
+                            request = args[idx] if args else None
                         if not isinstance(request, Request):
                             raise Exception(
                                 "parameter `request` must be an instance of starlette.requests.Request"
@@ -756,7 +758,9 @@ class Limiter:
                 def sync_wrapper(*args: Any, **kwargs: Any) -> Response:
                     # get the request object from the decorated endpoint function
                     if self.enabled:
-                        request = kwargs.get("request", args[idx] if args else None)
+                        request = kwargs.get("request")
+                        if not request:
+                            request = args[idx] if args else None
                         if not isinstance(request, Request):
                             raise Exception(
                                 "parameter `request` must be an instance of starlette.requests.Request"


### PR DESCRIPTION
### Summary

Fix for issue #284 .

User raised an issue that `args` were indexed too soon - before `kwargs` were searched.
This was due to trying to make this operation a 1-liner, and resulted in Python attempting to parse `args` before checking `kwargs`.

User supplied this proposed fix, which looks good and appears to cause no other issues.

### Checks done
- [x] tests pass
- [x] black formatter + linter pass
