### PR TITLE
fix: Misleading load order of kwargs vs. args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slowapi"
-version = "0.1.11"
+version = "0.1.10"
 description = "A rate limiting extension for Starlette and Fastapi"
 authors = ["Laurent Savaete <laurent@where.tf>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slowapi"
-version = "0.1.10"
+version = "0.1.11"
 description = "A rate limiting extension for Starlette and Fastapi"
 authors = ["Laurent Savaete <laurent@where.tf>"]
 license = "MIT"

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -724,7 +724,7 @@ class Limiter:
                     # get the request object from the decorated endpoint function
                     if self.enabled:
                         request = kwargs.get("request")
-                        if not request:
+                        if request is None:
                             request = args[idx] if args else None
                         if not isinstance(request, Request):
                             raise Exception(
@@ -759,7 +759,7 @@ class Limiter:
                     # get the request object from the decorated endpoint function
                     if self.enabled:
                         request = kwargs.get("request")
-                        if not request:
+                        if request is None:
                             request = args[idx] if args else None
                         if not isinstance(request, Request):
                             raise Exception(

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -723,7 +723,9 @@ class Limiter:
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Response:
                     # get the request object from the decorated endpoint function
                     if self.enabled:
-                        request = kwargs.get("request", args[idx] if args else None)
+                        request = kwargs.get("request")
+                        if not request:
+                            request = args[idx] if args else None
                         if not isinstance(request, Request):
                             raise Exception(
                                 "parameter `request` must be an instance of starlette.requests.Request"
@@ -756,7 +758,9 @@ class Limiter:
                 def sync_wrapper(*args: Any, **kwargs: Any) -> Response:
                     # get the request object from the decorated endpoint function
                     if self.enabled:
-                        request = kwargs.get("request", args[idx] if args else None)
+                        request = kwargs.get("request")
+                        if not request:
+                            request = args[idx] if args else None
                         if not isinstance(request, Request):
                             raise Exception(
                                 "parameter `request` must be an instance of starlette.requests.Request"

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -1,6 +1,7 @@
 import hiro  # type: ignore
 import pytest  # type: ignore
 from starlette.requests import Request
+from fastapi import APIRouter
 from starlette.responses import PlainTextResponse, Response
 from starlette.testclient import TestClient
 
@@ -369,3 +370,27 @@ class TestDecorators(TestSlowapi):
                 )
                 == 2
             )
+
+    def test_indexerror_class_route_args(self, build_fastapi_app):
+        """When using class-based routes, we search for 'request' in the kwargs and args of the decorated function
+        We previously checked 'args' before 'kwargs', causing an IndexError when 'request' was only in kwargs.
+        This test checks that no IndexError is raised, and that arguments are correctly parsed in these cases.
+        This is not an issue in non-class-based routes.
+        """
+        app, limiter = build_fastapi_app(key_func=get_ipaddr)
+
+        class NewRoutes:
+            def __init__(self):
+                self.router = APIRouter()
+                self.router.add_api_route(
+                    "/t1", self.check_request_kwargs, methods=["GET"]
+                )
+
+            @limiter.limit("5/minute")
+            def check_request_kwargs(self, request: Request):
+                return {"key": "value"}
+
+        app.include_router(NewRoutes().router)
+
+        client = TestClient(app)
+        client.get(url="/t1")

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -1,7 +1,7 @@
 import hiro  # type: ignore
 import pytest  # type: ignore
-from starlette.requests import Request
 from fastapi import APIRouter
+from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.testclient import TestClient
 
@@ -372,10 +372,11 @@ class TestDecorators(TestSlowapi):
             )
 
     def test_indexerror_class_route_args(self, build_fastapi_app):
-        """When using class-based routes, we search for 'request' in the kwargs and args of the decorated function
-        We previously checked 'args' before 'kwargs', causing an IndexError when 'request' was only in kwargs.
-        This test checks that no IndexError is raised, and that arguments are correctly parsed in these cases.
-        This is not an issue in non-class-based routes.
+        """When using class-based routes, we search for 'request'
+        in the kwargs and args of the decorated function. We previously checked
+        'args' before 'kwargs', causing an IndexError when 'request' was
+        only in kwargs. This test checks that no IndexError is raised, and
+        that arguments are correctly parsed. This is not an issue in non-class routes.
         """
         app, limiter = build_fastapi_app(key_func=get_ipaddr)
 


### PR DESCRIPTION
### Summary

Fix for issue #284 .

User raised an issue that `args` were indexed too soon - before `kwargs` were searched.
This was due to trying to make this operation a 1-liner, and resulted in Python attempting to parse `args` before checking `kwargs`.

User supplied this proposed fix, which looks good and appears to cause no other issues.

### Checks done
- [x] tests pass
- [x] black formatter + linter pass
