### PR TITLE
fix: replace deprecated asyncio.iscoroutinefunction with inspect variant

### DIFF
--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -717,7 +717,7 @@ class Limiter:
                     f'No "request" or "websocket" argument on function "{func}"'
                 )
 
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 # Handle async request/response functions.
                 @functools.wraps(func)
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Response:
@@ -874,7 +874,7 @@ class Limiter:
 
         self._exempt_routes.add(name)
 
-        if asyncio.iscoroutinefunction(obj):
+        if inspect.iscoroutinefunction(obj):
 
             @wraps(obj)
             async def __async_inner(*a, **k):


### PR DESCRIPTION
﻿## What

Replaces the two remaining `asyncio.iscoroutinefunction()` calls in `slowapi/extension.py` (L720, L877) with `inspect.iscoroutinefunction()`, fixing the `DeprecationWarning` reported in #263.

`asyncio.iscoroutinefunction` is deprecated as of Python 3.14; `inspect.iscoroutinefunction` is the documented drop-in replacement тАФ and it's already what `slowapi/middleware.py` uses, so this also makes the codebase consistent.

## Testing

- Full local suite: **97 passed** (`6 failed` failures are pre-existing on master with current starlette versions and unrelated to this change тАФ same result with/without the patch, tracked separately in #271)
- `import slowapi.extension` clean under Python 3.13

Closes #263




**Update:** the `6 failed` mentioned above were later traced to an unrelated float-epoch bug on master - fixed in #293, after which the suite is 103/103.
