### PR TITLE
Distinguish rate limits for same-named class methods

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -126,8 +126,12 @@ When calling the `/some_route/my_param` endpoint would result with a key shaped 
 limiter = Limiter(key_func=lambda: "mock", default_limits=["1/minute"], key_style="endpoint")
 ```
 
-When initializing the Limiter object with `key_style="endpoint"`, it will use the function name as part of the storage key.
+When initializing the Limiter object with `key_style="endpoint"`, it will use the function's module and qualified name (`__qualname__`) as part of the storage key.
+This distinguishes methods such as `First.index` and `Second.index` defined in the same module.
 
 When calling the `/some_route/my_param` endpoint would result with a key shaped like: `LIMITER/mock/{module}.my_func/1/1/minute`
 
 > This means, that if the route contains some URL parameter, calling the endpoint with different parameters will still share the limitations, since the view function is the same.
+
+> When upgrading from a version that uses `__name__`, class methods and nested functions use new storage keys, so their existing counters are not carried over.
+> Module-level functions and `key_style="url"` retain their storage keys.

--- a/slowapi/extension.py
+++ b/slowapi/extension.py
@@ -565,7 +565,7 @@ class Limiter:
         view_func = endpoint_func
 
         endpoint_func_name = (
-            f"{view_func.__module__}.{view_func.__name__}" if view_func else ""
+            f"{view_func.__module__}.{view_func.__qualname__}" if view_func else ""
         )
         _endpoint_key = endpoint_url if self._key_style == "url" else endpoint_func_name
         # cases where we don't need to check the limits
@@ -666,7 +666,7 @@ class Limiter:
 
         def decorator(func: Callable[..., Response]):
             keyfunc = key_func or self._key_func
-            name = f"{func.__module__}.{func.__name__}"
+            name = f"{func.__module__}.{func.__qualname__}"
             dynamic_limit = None
             static_limits: List[Limit] = []
             if callable(limit_value):
@@ -870,7 +870,7 @@ class Limiter:
         """
         Decorator to mark a view as exempt from rate limits.
         """
-        name = "%s.%s" % (obj.__module__, obj.__name__)
+        name = "%s.%s" % (obj.__module__, obj.__qualname__)
 
         self._exempt_routes.add(name)
 

--- a/slowapi/middleware.py
+++ b/slowapi/middleware.py
@@ -27,7 +27,7 @@ def _find_route_handler(
 
 
 def _get_route_name(handler: Callable):
-    return f"{handler.__module__}.{handler.__name__}"
+    return f"{handler.__module__}.{handler.__qualname__}"
 
 
 def _check_limits(

--- a/tests/test_fastapi_extension.py
+++ b/tests/test_fastapi_extension.py
@@ -22,6 +22,89 @@ class TestDecorators(TestSlowapi):
             response = client.get("/t1")
             assert response.status_code == 200 if i < 5 else 429
 
+    @pytest.mark.parametrize("key_style", ["url", "endpoint"])
+    @pytest.mark.parametrize(
+        "limit_value", ["2/minute", lambda: "2/minute"], ids=["static", "dynamic"]
+    )
+    def test_same_named_class_methods_have_independent_limits(
+        self, build_fastapi_app, key_style, limit_value
+    ):
+        app, limiter = build_fastapi_app(key_style=key_style)
+
+        class First:
+            @staticmethod
+            @app.get("/first")
+            @limiter.limit(limit_value)
+            async def index(request: Request):
+                return PlainTextResponse("first")
+
+        class Second:
+            @staticmethod
+            @app.get("/second")
+            @limiter.limit(limit_value)
+            def index(request: Request):
+                return PlainTextResponse("second")
+
+        with hiro.Timeline().freeze(), TestClient(app) as client:
+            assert [client.get("/first").status_code for _ in range(3)] == [
+                200,
+                200,
+                429,
+            ]
+            assert [client.get("/second").status_code for _ in range(3)] == [
+                200,
+                200,
+                429,
+            ]
+
+    def test_same_named_class_method_exemption_does_not_affect_default_limit(
+        self, build_fastapi_app
+    ):
+        app, limiter = build_fastapi_app(default_limits=["1/minute"])
+
+        class Exempt:
+            @staticmethod
+            @app.get("/exempt")
+            @limiter.exempt
+            async def index(request: Request):
+                return PlainTextResponse("exempt")
+
+        class Limited:
+            @staticmethod
+            @app.get("/limited")
+            def index(request: Request):
+                return PlainTextResponse("limited")
+
+        with hiro.Timeline().freeze(), TestClient(app) as client:
+            assert [client.get("/exempt").status_code for _ in range(2)] == [200, 200]
+            assert [client.get("/limited").status_code for _ in range(2)] == [200, 429]
+
+    def test_same_named_class_methods_keep_decorated_and_default_limits_separate(
+        self, build_fastapi_app
+    ):
+        app, limiter = build_fastapi_app(default_limits=["1/minute"])
+
+        class Decorated:
+            @staticmethod
+            @app.get("/decorated")
+            @limiter.limit("2/minute")
+            async def index(request: Request):
+                return PlainTextResponse("decorated")
+
+        class Default:
+            @staticmethod
+            @app.get("/default")
+            def index(request: Request):
+                return PlainTextResponse("default")
+
+        with hiro.Timeline().freeze(), TestClient(app) as client:
+            assert [client.get("/decorated").status_code for _ in range(3)] == [
+                200,
+                200,
+                429,
+            ]
+            assert [client.get("/default").status_code for _ in range(2)] == [200, 429]
+
     def test_single_decorator_with_headers(self, build_fastapi_app):
         app, limiter = build_fastapi_app(key_func=get_ipaddr, headers_enabled=True)
 
@@ -365,7 +448,8 @@ class TestDecorators(TestSlowapi):
             # check that we counted 2 requests, even though we had a different value for "my_param"
             assert (
                 limiter._storage.get(
-                    "LIMITER/mock/tests.test_fastapi_extension.t1_func/1/1/minute"
+                    "LIMITER/mock/tests.test_fastapi_extension."
+                    "TestDecorators.test_key_style.<locals>.t1_func/1/1/minute"
                 )
                 == 2
             )

--- a/tests/test_starlette_extension.py
+++ b/tests/test_starlette_extension.py
@@ -408,7 +408,8 @@ class TestDecorators(TestSlowapi):
             # check that we counted 2 requests, even though we had a different value for "my_param"
             assert (
                 limiter._storage.get(
-                    "LIMITER/mock/tests.test_starlette_extension.t1_func/1/1/minute"
+                    "LIMITER/mock/tests.test_starlette_extension."
+                    "TestDecorators.test_key_style.<locals>.t1_func/1/1/minute"
                 )
                 == 2
             )


### PR DESCRIPTION
Rate-limit registration and lookup currently identify endpoints using their module and `__name__`, so methods such as `First.index` and `Second.index` share configuration. This can apply limits twice or allow one route's exemption to bypass another route's limit.

Use `__qualname__` consistently for registration, lookup, exemptions, and middleware matching. Add regression tests for synchronous and asynchronous endpoints, static and dynamic limits, both key styles, exemptions, and default limits.

With `key_style="endpoint"`, class methods and nested functions receive new storage keys, so existing counters are not carried over. Module-level functions and URL-based keys keep their existing keys. This behavior is documented in the examples.

Validation on Python 3.11 using the existing lock file: all 18 regression cases fail before the fix and pass afterward; all 121 tests pass after the fix. Black, mypy, and flake8 F401 pass. Documentation builds with MkDocs strict in a separate environment using compatible Markdown/importlib-metadata versions; the lock-file documentation environment fails during import on Python 3.11.

Fixes #173.
